### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/SuperLinter.yml
+++ b/.github/workflows/SuperLinter.yml
@@ -43,7 +43,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v8.5.0
+        uses: super-linter/super-linter/slim@v8
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: master


### PR DESCRIPTION
## Summary

Updates all GitHub Actions to their latest major versions and ensures Dependabot is configured to keep them current.

### Why
Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 2, 2026.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>